### PR TITLE
Standardize .phpcs.xml

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <ruleset name="MediaWiki">
-	<rule ref="./vendor/mediawiki/mediawiki-codesniffer/MediaWiki">
-	</rule>
+	<rule ref="./vendor/mediawiki/mediawiki-codesniffer/MediaWiki" />
 	<file>.</file>
 	<arg name="encoding" value="UTF-8"/>
 	<arg name="extensions" value="php"/>


### PR DESCRIPTION
To be like for other MediaWiki extensions, for cases when there are no excluded rules. :)